### PR TITLE
Fix GitHub Actions token env

### DIFF
--- a/.github/workflows/zola.yml
+++ b/.github/workflows/zola.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
+    env:
+      TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,6 +28,9 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    env:
+      TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,4 +42,3 @@ jobs:
         uses: shalzz/zola-deploy-action@v0.17.2
         env:
           PAGES_BRANCH: gh-pages
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ _site
 .DS_Store
 .claude/
 public/
+zola
+zola.tar.gz

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Visit: [https://laydros.github.io](https://laydros.github.io)
 ### Prerequisites
 
 - [Zola](https://www.getzola.org/documentation/getting-started/installation/) static site generator
+- Or run `scripts/setup_zola.sh` to download a prebuilt binary
 
 ### Development Workflow
 

--- a/scripts/setup_zola.sh
+++ b/scripts/setup_zola.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Zola if not already available
+if command -v zola >/dev/null 2>&1; then
+  echo "Zola already installed: $(zola --version)"
+  exit 0
+fi
+
+# Determine version (use ZOLA_VERSION env var or latest release)
+VERSION=${ZOLA_VERSION:-$(curl -s https://api.github.com/repos/getzola/zola/releases/latest | grep -Po '"tag_name": "v\K[0-9.]+' )}
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64) ARCH="x86_64-unknown-linux-gnu";;
+  aarch64|arm64) ARCH="aarch64-unknown-linux-gnu";;
+  *) echo "Unsupported architecture: $ARCH"; exit 1;;
+esac
+URL="https://github.com/getzola/zola/releases/download/v${VERSION}/zola-v${VERSION}-${ARCH}.tar.gz"
+
+echo "Downloading Zola ${VERSION} from ${URL}"
+
+curl -LsSf "$URL" -o /tmp/zola.tar.gz
+mkdir -p /tmp/zola-install
+
+tar -xzf /tmp/zola.tar.gz -C /tmp/zola-install zola
+chmod +x /tmp/zola-install/zola
+sudo mv /tmp/zola-install/zola /usr/local/bin/zola
+rm -rf /tmp/zola.tar.gz /tmp/zola-install
+
+echo "Zola installed: $(zola --version)"


### PR DESCRIPTION
## Summary
- add token environment variables at the job level so zola-deploy-action runs
- provide `scripts/setup_zola.sh` to download a Zola binary when missing
- ignore downloaded binaries
- document the helper script in README

## Testing
- `bash -x scripts/setup_zola.sh` *(fails to fetch due to blocked network)*
- `zola --version` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6883b34d98008329827df5a27f4a77db