### PR TITLE
Align start-d with start template

### DIFF
--- a/static/start-d/style.css
+++ b/static/start-d/style.css
@@ -1,3 +1,10 @@
+/* Reset and base styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
 /* Theme definitions */
 :root[data-theme="original"] {
     --bg-primary: #000000;
@@ -64,6 +71,37 @@ body {
     }
 }
 
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Header */
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 3rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.title {
+    font-size: 2rem;
+    font-weight: 300;
+    color: var(--text-primary);
+    letter-spacing: -0.5px;
+}
+
+.theme-switcher {
+    display: flex;
+    gap: 0.5rem;
+}
+
 .info {
     display: flex;
     justify-content: left;
@@ -94,10 +132,12 @@ body {
     }
 }
 
-.list_title {
+.lists h2 {
     font-size: 25px;
     color: var(--accent);
     transition: color 0.3s ease;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
 }
 
 .lists {
@@ -109,11 +149,9 @@ body {
     font-family: 'Barlow', sans-serif;
 }
 
-.tools,
-.nix,
-.dev,
-.media,
-.other {
+
+.lists ul {
+    list-style: none;
     display: flex;
     flex-direction: column;
     border: 2px solid var(--card-border);
@@ -126,11 +164,7 @@ body {
 }
 
 /* Links - using /start/ style (no permanent background) */
-.tools a,
-.dev a, 
-.nix a,
-.media a,
-.other a {
+.lists a {
     display: block;
     color: var(--text-primary);
     text-decoration: none;
@@ -143,33 +177,17 @@ body {
     overflow: hidden;
 }
 
-.tools a:hover,
-.dev a:hover,
-.nix a:hover, 
-.media a:hover,
-.other a:hover {
+.lists a:hover {
     background-color: var(--bg-secondary);
     color: var(--accent-hover);
     transform: translateX(4px);
     box-shadow: 0 2px 8px var(--shadow);
 }
 
-.tools a:active,
-.dev a:active,
-.nix a:active,
-.media a:active, 
-.other a:active {
+.lists a:active {
     transform: translateX(2px);
 }
 
-#t,
-#d,
-#l,
-#m,
-#o {
-    color: var(--accent);
-    transition: color 0.3s ease;
-}
 
 #mode {
     filter: invert(100%) sepia(0%) saturate(1620%) hue-rotate(8deg) brightness(94%) contrast(88%)
@@ -181,12 +199,8 @@ body {
 
 /* Theme Switcher */
 .theme-switcher {
-    position: fixed;
-    top: 20px;
-    right: 20px;
     display: flex;
-    gap: 8px;
-    z-index: 1000;
+    gap: 0.5rem;
 }
 
 .theme-btn {
@@ -218,12 +232,6 @@ body {
 }
 
 @media (max-width: 600px) {
-    .theme-switcher {
-        top: 10px;
-        right: 10px;
-        gap: 6px;
-    }
-    
     .theme-btn {
         width: 36px;
         height: 36px;
@@ -251,4 +259,52 @@ body {
 .footer a:hover {
     color: var(--accent-hover);
     font-style: italic;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+    .container {
+        padding: 1rem;
+    }
+
+    .header {
+        flex-direction: column;
+        gap: 1rem;
+        text-align: center;
+    }
+
+    .title {
+        font-size: 1.5rem;
+    }
+
+    .theme-switcher {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 1024px) and (min-width: 769px) {
+    /* no grid columns needed but reserved for future */
+}
+
+@media (max-width: 480px) {
+    .container {
+        padding: 0.5rem;
+    }
+
+    .lists h2 {
+        font-size: 1.1rem;
+    }
+
+    .lists a {
+        font-size: 0.9rem;
+        padding: 0.4rem 0.6rem;
+    }
+}
+
+/* Focus styles for accessibility */
+.theme-btn:focus,
+.lists a:focus,
+.footer a:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
 }

--- a/templates/start-d.html
+++ b/templates/start-d.html
@@ -15,62 +15,31 @@
 </head>
 
 <body data-theme="original">
-    <div class="theme-switcher">
-        <button class="theme-btn" data-theme="original" title="Original Theme">🏠</button>
-        <button class="theme-btn" data-theme="vscode" title="VS Code Dark">⚫</button>
-        <button class="theme-btn" data-theme="catppuccin" title="Catppuccin">🌙</button>
-        <button class="theme-btn" data-theme="dracula" title="Dracula">🧛</button>
+    <div class="container">
+        <header class="header">
+            <h1 class="title">start-d</h1>
+            <div class="theme-switcher">
+                <button class="theme-btn" data-theme="original" title="Original Theme">🏠</button>
+                <button class="theme-btn" data-theme="vscode" title="VS Code Dark">⚫</button>
+                <button class="theme-btn" data-theme="catppuccin" title="Catppuccin">🌙</button>
+                <button class="theme-btn" data-theme="dracula" title="Dracula">🧛</button>
+            </div>
+        </header>
+
+        <div class="info">
+            <p id="time"></p>
+            <h1 id="greeting"></h1>
+        </div>
+
+        <main class="lists">
+            {{ section.content | safe }}
+        </main>
+
+        <footer class="footer">
+            <a href="/">← back to main site</a>
+        </footer>
     </div>
-    
-    <div class="info">
-        <p id="time"></p>
-        <h1 id="greeting"></h1>
-    </div>
-    <div class="lists">
-        <div class="tools">
-            <p class="list_title" id="t">Tools</p>
-            <a href="https://fastmail.com/">fastmail</a>
-            <a href="https://mail.protonmail.com/">protonmail</a>
-            <a href="https://claude.ai">Claude</a>
-            <a href="https://chat.openai.com">ChatGPT</a>
-            <a href="https://www.perplexity.ai">Perplexity.ai</a>
-            <a href="https://x.ai">Grok (xAI)</a>
-            <a href="https://localhost:8384/">syncthing</a>
-        </div>
-        <div class="dev">
-            <p class="list_title" id="d">Dev</p>
-            <a href="https://chatgpt.com/codex">ChatGPT Codex</a>
-            <a href="https://github.com/">github</a>
-            <a href="https://sourcehut.org/">sourcehut(fka sr.ht)</a>
-        </div>
-        <div class="nix">
-            <p class="list_title" id="l">*Nix</p>
-            <a href="https://wiki.archlinux.org/">Arch Wiki</a>
-            <a href="https://alltop.com/linux">Alltop/linux</a>
-            <a href="https://reddit.com/r/unixporn">unixporn</a>
-            <a href="https://xn--gckvb8fzb.com">ごくふつうのブログ</a>
-            <a href="http://start.laydros.net/openbsd_install.html">OpenBSD install</a>
-        </div>
-        <div class="media">
-            <p class="list_title" id="m">Media</p>
-            <a href="https://www.reddit.com/">Reddit</a>
-            <a href="https://www.youtube.com">YouTube</a>
-            <a href="https://lobste.rs/">lobsters</a>
-            <a href="https://news.ycombinator.com/">hacker news</a>
-            <a href="https://www.daringfireball.net/">df</a>
-            <a href="https://www.leancrew.com/all-this/">dr. drang</a>
-            <a href="https://xkcd.com/">xkcd</a>
-            <a href="https://www.theverge.com">The Verge</a>
-            <a href="https://www.macrumors.com">MacRumors</a>
-            <a href="https://9to5mac.com">9to5Mac</a>
-            <a href="https://slickdeals.net/deals/musical-instruments/">SD insruments</a>
-        </div>
-    </div>
-    
-    <footer class="footer">
-        <a href="/">← back to main site</a>
-    </footer>
-    
+
     <script async type="text/javascript" src="{{ get_url(path='start-d/script.js') }}"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- make `/start-d/` template use markdown content
- add containerized layout and header
- update `/start-d/` styles with reset, layout, responsive and focus rules

## Testing
- `zola build`

------
https://chatgpt.com/codex/tasks/task_e_6888173ac8688329846f36da1481f5bf