### PR TITLE
Add theme dropdown for start page

### DIFF
--- a/static/start/script.js
+++ b/static/start/script.js
@@ -1,7 +1,7 @@
 // Startpage theme management for start
 class StartpageThemeManager {
     constructor() {
-        this.themes = ['original', 'vscode', 'catppuccin', 'dracula'];
+        this.themes = ['original', 'vscode', 'catppuccin', 'dracula', 'tokyonight', 'ayu-light'];
         this.currentTheme = 'original';
         this.storageKey = 'startpage-d-theme';
         this.init();
@@ -12,15 +12,16 @@ class StartpageThemeManager {
         const savedTheme = localStorage.getItem(this.storageKey) || 'original';
         this.setTheme(savedTheme);
 
-        // Add event listeners to theme buttons
-        document.querySelectorAll('.theme-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const theme = e.target.dataset.theme;
+        // Add event listener to dropdown
+        const select = document.getElementById('theme-select');
+        if (select) {
+            select.addEventListener('change', (e) => {
+                const theme = e.target.value;
                 this.setTheme(theme);
             });
-        });
+        }
 
-        // Update active button state
+        // Update active option state
         this.updateActiveButton();
     }
 
@@ -34,18 +35,21 @@ class StartpageThemeManager {
     }
 
     updateActiveButton() {
-        document.querySelectorAll('.theme-btn').forEach(btn => {
-            btn.classList.toggle('active', btn.dataset.theme === this.currentTheme);
-        });
+        const select = document.getElementById('theme-select');
+        if (select) {
+            select.value = this.currentTheme;
+        }
     }
 }
+
+let themeManager;
 
 // Time and greeting functionality
 const determineGreet = hours => document.getElementById("greeting").innerText = `Good ${hours < 12 ? "Morning." : hours < 18 ? "Afternoon." : "Evening."}`;
 
 window.addEventListener('load', (event) => {
     // Initialize theme manager
-    new StartpageThemeManager();
+    themeManager = new StartpageThemeManager();
 
     // Set up greeting and time
     let today = new Date();
@@ -118,15 +122,14 @@ document.addEventListener('keydown', (e) => {
     // Only activate shortcuts if we're not focused on input fields
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
 
-    // Ctrl/Cmd + 1,2,3,4 for theme switching
-    if ((e.ctrlKey || e.metaKey) && e.key >= '1' && e.key <= '4') {
+    // Ctrl/Cmd + 1-6 for theme switching
+    if ((e.ctrlKey || e.metaKey) && e.key >= '1' && e.key <= '6') {
         e.preventDefault();
         const themeIndex = parseInt(e.key) - 1;
-        const themes = ['original', 'vscode', 'catppuccin', 'dracula'];
+        const themes = ['original', 'vscode', 'catppuccin', 'dracula', 'tokyonight', 'ayu-light'];
         const theme = themes[themeIndex];
 
         if (theme) {
-            const themeManager = new StartpageThemeManager();
             themeManager.setTheme(theme);
         }
     }

--- a/static/start/style.css
+++ b/static/start/style.css
@@ -53,6 +53,32 @@
     --shadow: rgba(0, 0, 0, 0.5);
 }
 
+:root[data-theme="tokyonight"] {
+    --bg-primary: #1a1b26;
+    --bg-secondary: #24283b;
+    --text-primary: #c0caf5;
+    --text-secondary: #a9b1d6;
+    --accent: #7aa2f7;
+    --accent-hover: #7dcfff;
+    --border: #414868;
+    --card-border: #414868;
+    --card-bg: #24283b;
+    --shadow: rgba(0, 0, 0, 0.5);
+}
+
+:root[data-theme="ayu-light"] {
+    --bg-primary: #fcfcfc;
+    --bg-secondary: #ffffff;
+    --text-primary: #5c6166;
+    --text-secondary: #889095;
+    --accent: #e6b450;
+    --accent-hover: #ffb454;
+    --border: #d7d8d2;
+    --card-border: #d7d8d2;
+    --card-bg: #ffffff;
+    --shadow: rgba(0, 0, 0, 0.2);
+}
+
 body {
     background-color: var(--bg-primary);
     transition: background-color 0.3s ease, color 0.3s ease;
@@ -173,6 +199,19 @@ body {
     display: flex;
     gap: 8px;
     z-index: 1000;
+}
+
+.theme-select {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    border-radius: 8px;
+    padding: 6px 8px;
+    font-size: 16px;
+}
+.theme-select:hover {
+    background: var(--accent);
+    color: var(--bg-primary);
 }
 
 .theme-btn {

--- a/templates/start.html
+++ b/templates/start.html
@@ -17,10 +17,14 @@
 <body data-theme="original">
 
     <div class="theme-switcher">
-        <button class="theme-btn" data-theme="original" title="Original Theme">🏠</button>
-        <button class="theme-btn" data-theme="vscode" title="VS Code Dark">⚫</button>
-        <button class="theme-btn" data-theme="catppuccin" title="Catppuccin">🌙</button>
-        <button class="theme-btn" data-theme="dracula" title="Dracula">🧛</button>
+        <select id="theme-select" class="theme-select" aria-label="Choose theme">
+            <option value="original">🏠 Original</option>
+            <option value="vscode">⚫ VS Code Dark</option>
+            <option value="catppuccin">🐱 Catppuccin</option>
+            <option value="dracula">🧛 Dracula</option>
+            <option value="tokyonight">🌃 Tokyo Night</option>
+            <option value="ayu-light">🌅 Ayu Light</option>
+        </select>
     </div>
 
     <div class="info">


### PR DESCRIPTION
## Summary
- update theme switcher UI to use a dropdown
- support two new themes (Tokyo Night and Ayu Light)
- change Catppuccin icon to a cat
- update JavaScript for new themes and keyboard shortcuts

## Testing
- `zola check` *(fails: error sending request for external links)*
- `zola build`


------
https://chatgpt.com/codex/tasks/task_e_688847b39d7c832984c2b90019f37c57